### PR TITLE
15 fix monster recipes form #27

### DIFF
--- a/app/controllers/admin/monster_recipes_controller.rb
+++ b/app/controllers/admin/monster_recipes_controller.rb
@@ -7,12 +7,8 @@ class Admin::MonsterRecipesController < ApplicationController
   end
 
   def create
-    monster_recipe_params[:recipe_id].each do | r |
-      monster_recipe = MonsterRecipe.new(recipe_id: r.to_i)
-      monster_recipe.monster_id = monster_recipe_params[:monster_id]
-      monster_recipe.save!
-    end
-    redirect_to admin_monsters_path
+    @monster = MonsterRecipe.new(monster_recipe_params)
+    @monster.save!
   end
 
   def destroy

--- a/app/controllers/admin/monster_recipes_controller.rb
+++ b/app/controllers/admin/monster_recipes_controller.rb
@@ -20,6 +20,6 @@ class Admin::MonsterRecipesController < ApplicationController
   private
 
   def monster_recipe_params
-    params.require(:monster_recipe).permit(:monster_id, recipe_id: [])
+    params.require(:monster_recipe).permit(:monster_id, :recipe_id, :order_num)
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -6,7 +6,8 @@ class GamesController < ApplicationController
     gon.user_attack_point = user_attack_point
 
     names = []
-    @monster.recipes.each do |recipe|
+    recipe_order = @monster.recipes.order(:order_num)
+    recipe_order.each do |recipe|
       names.push(recipe.name)
     end
     gon.names = names

--- a/app/views/admin/monster_recipes/new.html.erb
+++ b/app/views/admin/monster_recipes/new.html.erb
@@ -1,9 +1,11 @@
-<%= form_with model: @monster_recipe, url: admin_monster_recipes_path do |f| %>
+<%= form_with model: @monster_recipe, url: admin_monster_recipes_path,local: false do |f| %>
 <%= render 'shared/error_messages', object: f.object %>
     <%= f.label :monster_id %>
     <%= f.select :monster_id, Monster.pluck(:name, :id), class: 'form-control'  %>
-    <%= f.collection_check_boxes(:recipe_id, Recipe.all, :id, :name, include_hidden: false) do |b| %>
-      <%= b.label { b.check_box + b.text } %>
-    <% end %>
+    <%= f.label :recipe_id %>
+    <%= f.select :recipe_id, Recipe.pluck(:name, :id), class: 'form-control'  %>
+    <%= f.label :order_num %>
+    <%= f.number_field :order_num,class:'form-control' %>
     <%= f.submit "一括登録"%>
 <%end%> 
+<%= link_to 'モンスター一覧へ', admin_monsters_path %>

--- a/app/views/admin/monster_recipes/new.html.erb
+++ b/app/views/admin/monster_recipes/new.html.erb
@@ -1,9 +1,9 @@
 <%= form_with model: @monster_recipe, url: admin_monster_recipes_path,local: false do |f| %>
 <%= render 'shared/error_messages', object: f.object %>
     <%= f.label :monster_id %>
-    <%= f.select :monster_id, Monster.pluck(:name, :id), class: 'form-control'  %>
+    <%= f.select :monster_id, Monster.pluck(:name, :id), include_blank: true, class: 'form-control'  %>
     <%= f.label :recipe_id %>
-    <%= f.select :recipe_id, Recipe.pluck(:name, :id), class: 'form-control'  %>
+    <%= f.select :recipe_id, Recipe.pluck(:name, :id), include_blank: true, class: 'form-control'  %>
     <%= f.label :order_num %>
     <%= f.number_field :order_num,class:'form-control' %>
     <%= f.submit "一括登録"%>

--- a/db/migrate/20220116080120_add_order_num_to_monster_recipes.rb
+++ b/db/migrate/20220116080120_add_order_num_to_monster_recipes.rb
@@ -1,0 +1,5 @@
+class AddOrderNumToMonsterRecipes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :monster_recipes, :order_num, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_11_033646) do
+ActiveRecord::Schema.define(version: 2022_01_16_080120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2022_01_11_033646) do
     t.bigint "recipe_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "order_num"
     t.index ["monster_id"], name: "index_monster_recipes_on_monster_id"
     t.index ["recipe_id"], name: "index_monster_recipes_on_recipe_id"
   end


### PR DESCRIPTION
## 概要

モンスターに紐づくレシピを作る順番通りに並び替えられない事を発見したので、修正しました。
ご確認お願いいたします。

## 確認方法

1. カラムを追加したので `bundle exec rails db:migrate` を実行してください
2. ゲーム画面で発生するレシピが作る順番通りになっていることを確認してください。

## チェックリスト

- [x] monster_recipesテーブルに順番を意味するorder_numカラムを追加する。
- [x] monster_recipesフォームに順番の入力を追加する
- [x] 以上に伴うmonster_recipesコントローラーの修正

## コメント

モンスターレシピの作成はajax通信で行っています。

close #27